### PR TITLE
Add radio_instance_new_with_opts() API

### DIFF
--- a/include/radio_instance.h
+++ b/include/radio_instance.h
@@ -119,6 +119,30 @@ radio_instance_new(
     const char* dev,
     const char* name);
 
+/**
+ * opts is a (char*) -> (char*) hash table or NULL to use defaults.
+ * Supported keys and default values:
+ *
+ * "dev" = "/dev/hwbinder"
+ * "name" = "slot1"
+
+ * "radio-interface" =
+ * "android.hardware.radio@1.0::IRadio"
+
+ * "response-interfaces" =
+ * "android.hardware.radio@1.0::IRadioResponse,android.hidl.base@1.0::IBase"
+
+ * "indication-interfaces" =
+ * "android.hardware.radio@1.0::IRadioIndication,android.hidl.base@1.0::IBase"
+ *
+ * Multiple binder interfaces are separated with commas, the top-most
+ * interface coming first. Default interfaces can be omitted, and they
+ * are appended to the interface chain if they are missing.
+ */
+RadioInstance*
+radio_instance_new_with_opts(
+    GHashTable* opts); /* Since 1.0.2 */
+
 RadioInstance*
 radio_instance_get(
     const char* dev,

--- a/rpm/libgbinder-radio.spec
+++ b/rpm/libgbinder-radio.spec
@@ -8,7 +8,8 @@ URL: https://github.com/mer-hybris/libgbinder-radio
 Source: %{name}-%{version}.tar.bz2
 BuildRequires: pkgconfig(glib-2.0)
 BuildRequires: pkgconfig(libglibutil)
-BuildRequires: pkgconfig(libgbinder)
+BuildRequires: pkgconfig(libgbinder) >= 1.0.29
+Requires: libgbinder >= 1.0.29
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 


### PR DESCRIPTION
Allows to use custom binder interfraces derived from `android.hardware.radio@1.0` interfaces.