### PR TITLE
Expose GBinderRemoteObject

### DIFF
--- a/include/radio_instance.h
+++ b/include/radio_instance.h
@@ -52,6 +52,8 @@ struct radio_instance {
     const char* dev;
     const char* slot;
     const char* key;
+    /* Since 1.0.7 */
+    GBinderRemoteObject* remote;
 };
 
 typedef


### PR DESCRIPTION
Note that it may spontaneously become NULL if the remove object dies.