### PR TITLE
Fix retries of blocking requests

### DIFF
--- a/src/radio_base.c
+++ b/src/radio_base.c
@@ -363,8 +363,8 @@ radio_base_can_submit_request(
     RadioRequest* req)
 {
     if (priv->block_req) {
-        /* A request (presumably a different one) is blocking everything */
-        return FALSE;
+        /* The current blocker can be resubmitted */
+        return priv->block_req == req;
     } else if (req->group) {
         /* The request is a part of a group */
         if (req->group == priv->owner) {
@@ -437,8 +437,10 @@ radio_base_submit_queued_requests(
                     radio_base_move_owner_queue(self);
                     submitted++;
                     if (req->blocking) {
-                        GVERBOSE_("block %p => %p", priv->block_req, req);
-                        priv->block_req = radio_request_ref(req);
+                        if (!priv->block_req) {
+                            GVERBOSE_("block %p => %p", priv->block_req, req);
+                            priv->block_req = radio_request_ref(req);
+                        }
                         break;
                     }
                 } else {

--- a/src/radio_request.c
+++ b/src/radio_request.c
@@ -125,7 +125,17 @@ radio_request_default_retry(
     const GBinderReader* reader,
     void* user_data)
 {
-    return status != RADIO_TX_STATUS_OK || error != RADIO_ERROR_NONE;
+    if (status != RADIO_TX_STATUS_OK) {
+        GVERBOSE_("req %p %u (%08x) status %d", req, req->code, req->serial,
+            status);
+        return TRUE;
+    } else if (error != RADIO_ERROR_NONE) {
+        GVERBOSE_("req %p %u (%08x) error %d", req, req->code, req->serial,
+            error);
+        return TRUE;
+    } else {
+        return FALSE;
+    }
 }
 
 static


### PR DESCRIPTION
If a blocking request failed, it was never retried after that, even if retries were enabled.