### PR TITLE
Add RADIO_ACCESS_NETWORKS enum

### DIFF
--- a/include/radio_types.h
+++ b/include/radio_types.h
@@ -501,6 +501,7 @@ typedef enum radio_data_request_reason {
 } RADIO_DATA_REQUEST_REASON; /* Since 1.2.0 */
 G_STATIC_ASSERT(sizeof(RADIO_DATA_REQUEST_REASON) == 4);
 
+/* This is AccessNetwork from types.hal */
 typedef enum radio_access_network {
     RADIO_ACCESS_NETWORK_UNKNOWN,
     RADIO_ACCESS_NETWORK_GERAN,
@@ -511,6 +512,17 @@ typedef enum radio_access_network {
     RADIO_ACCESS_NETWORK_NGRAN /* Since 1.5.0 */
 } RADIO_ACCESS_NETWORK; /* Since 1.2.0 */
 G_STATIC_ASSERT(sizeof(RADIO_ACCESS_NETWORK) == 4);
+
+/* And this is RadioAccessNetworks (easy to confuse with AccessNetwork) */
+typedef enum radio_access_networks {
+    RADIO_ACCESS_NETWORKS_UNKNOWN,
+    RADIO_ACCESS_NETWORKS_GERAN,
+    RADIO_ACCESS_NETWORKS_UTRAN,
+    RADIO_ACCESS_NETWORKS_EUTRAN,
+    RADIO_ACCESS_NETWORKS_NGRAN,
+    RADIO_ACCESS_NETWORKS_CDMA2000
+} RADIO_ACCESS_NETWORKS; /* Since 1.5.3 */
+G_STATIC_ASSERT(sizeof(RADIO_ACCESS_NETWORKS) == 4);
 
 typedef enum radio_data_profile_type {
     RADIO_DATA_PROFILE_COMMON,
@@ -2205,7 +2217,7 @@ typedef struct radio_network_scan_result {
 G_STATIC_ASSERT(sizeof(RadioNetworkScanResult) == 24);
 
 typedef struct radio_network_scan_specifier {
-    RADIO_ACCESS_NETWORK radioAccessNetwork RADIO_ALIGNED(4);
+    RADIO_ACCESS_NETWORKS radioAccessNetwork RADIO_ALIGNED(4);
     GBinderHidlVec geranBands RADIO_ALIGNED(8); /* vec<RADIO_GERAN_BAND> */
     GBinderHidlVec utranBands RADIO_ALIGNED(8); /* vec<RADIO_UTRAN_BAND> */
     GBinderHidlVec eutranBands RADIO_ALIGNED(8); /* vec<RADIO_EUTRAN_BAND> */
@@ -2214,7 +2226,7 @@ typedef struct radio_network_scan_specifier {
 G_STATIC_ASSERT(sizeof(RadioAccessSpecifier) == 72);
 
 typedef struct radio_network_scan_specifier_1_5 {
-    RADIO_ACCESS_NETWORK radioAccessNetwork RADIO_ALIGNED(4);
+    RADIO_ACCESS_NETWORKS radioAccessNetwork RADIO_ALIGNED(4);
     guint8 type RADIO_ALIGNED(8); /* RADIO_NETWORK_SCAN_SPECIFIER_1_5_TYPE */
     GBinderHidlVec bands RADIO_ALIGNED(8);  /* vec<RADIO_GERAN_BAND> */
                                          /* or vec<RADIO_UTRAN_BAND> */

--- a/include/radio_types.h
+++ b/include/radio_types.h
@@ -1619,11 +1619,11 @@ typedef struct radio_cell_info_1_2 {
     guint8 registered RADIO_ALIGNED(1);
     gint32 timeStampType RADIO_ALIGNED(4);
     guint64 timeStamp RADIO_ALIGNED(8);
-    GBinderHidlVec gsm RADIO_ALIGNED(8);     /* vec<RadioCellInfoGsm> */
-    GBinderHidlVec cdma RADIO_ALIGNED(8);    /* vec<RadioCellInfoCdma> */
-    GBinderHidlVec lte RADIO_ALIGNED(8);     /* vec<RadioCellInfoLte> */
-    GBinderHidlVec wcdma RADIO_ALIGNED(8);   /* vec<RadioCellInfoWcdma> */
-    GBinderHidlVec tdscdma RADIO_ALIGNED(8); /* vec<RadioCellInfoTdscdma> */
+    GBinderHidlVec gsm RADIO_ALIGNED(8);     /* vec<RadioCellInfoGsm_1_2> */
+    GBinderHidlVec cdma RADIO_ALIGNED(8);    /* vec<RadioCellInfoCdma_1_2> */
+    GBinderHidlVec lte RADIO_ALIGNED(8);     /* vec<RadioCellInfoLte_1_2> */
+    GBinderHidlVec wcdma RADIO_ALIGNED(8);   /* vec<RadioCellInfoWcdma_1_2> */
+    GBinderHidlVec tdscdma RADIO_ALIGNED(8); /* vec<RadioCellInfoTdscdma_1_2> */
     RADIO_CELL_CONNECTION_STATUS connectionStatus RADIO_ALIGNED(4);
 } RADIO_ALIGNED(8) RadioCellInfo_1_2; /* Since 1.2.0 */
 G_STATIC_ASSERT(sizeof(RadioCellInfo_1_2) == 112);
@@ -2055,7 +2055,7 @@ G_STATIC_ASSERT(sizeof(RadioCellInfoNr) == 112);
 
 typedef struct radio_cell_info_1_4 {
     guint8 registered RADIO_ALIGNED(1);
-    guint32 connectionStatus RADIO_ALIGNED(4);
+    RADIO_CELL_CONNECTION_STATUS connectionStatus RADIO_ALIGNED(4);
     guint8 cellInfoType RADIO_ALIGNED(1); /* RADIO_CELL_INFO_TYPE_1_4 */
     union {
         RadioCellInfoGsm_1_2 gsm RADIO_ALIGNED(8);
@@ -2102,7 +2102,7 @@ typedef struct radio_cell_info_1_5 {
     guint8 registered RADIO_ALIGNED(1);
     gint32 timeStampType RADIO_ALIGNED(4);
     guint64 timeStamp RADIO_ALIGNED(8);
-    guint32 connectionStatus RADIO_ALIGNED(4);
+    RADIO_CELL_CONNECTION_STATUS connectionStatus RADIO_ALIGNED(4);
     guint8 cellInfoType RADIO_ALIGNED(8); /* RADIO_CELL_INFO_TYPE_1_5 */
     union {
         RadioCellInfoGsm_1_5 gsm RADIO_ALIGNED(8);


### PR DESCRIPTION
There are two similar enums defined in `types.hal` files, `AccessNetwork` and `RadioAccessNetworks`. They can be easily confused with each other and yet their enum values e.g. for `NGRAN` are different (although `GERAN`, `UTRAN` and `EUTRAN` values match). Our mapping goes like this:

  AccessNetwork => RADIO_ACCESS_NETWORK
  RadioAccessNetworks => RADIO_ACCESS_NETWORKS