### PR TITLE
Fix compilation error

### DIFF
--- a/src/radio_instance.c
+++ b/src/radio_instance.c
@@ -796,7 +796,7 @@ radio_instance_create(
     RadioInstance* self = NULL;
     GBinderServiceManager* sm = gbinder_servicemanager_new(dev);
     const RadioInterfaceDesc* interfaces = NULL;
-    gsize num_interfaces = 0;
+    gsize i, num_interfaces = 0;
 
     if (!sm) {
         GERR_("Failed to get ServiceManager on %s", dev);
@@ -812,7 +812,7 @@ radio_instance_create(
         num_interfaces = 1;
     }
 
-    for (guint i = 0; i < num_interfaces && !self; i++) {
+    for (i = 0; i < num_interfaces && !self; i++) {
         const RadioInterfaceDesc* desc = interfaces + i;
 
         if (desc->version <= max_version) {


### PR DESCRIPTION
```
src/radio_instance.c: In function 'radio_instance_create': src/radio_instance.c:815:5: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
     for (guint i = 0; i < num_interfaces && !self; i++) {
     ^
src/radio_instance.c:815:5: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
```
I realize that this is an old gcc but why not to remain compatible with it.