### PR TITLE
Makefile: honor an externally provided CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ COVERAGE_BUILD_DIR = $(BUILD_DIR)/coverage
 # Tools and flags
 #
 
-CC = $(CROSS_COMPILE)gcc
+CC ?= $(CROSS_COMPILE)gcc
 LD = $(CC)
 WARNINGS = -Wall -Wstrict-aliasing -Wunused-result
 DEFINES += -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_30 \


### PR DESCRIPTION
Hi folks! Checking in from AsteroidOS here.

Let the build system pick the compiler. The Makefile hard-codes its own CC and ignores the cross-compiler the build environment provides, so cross-compiles wrongly fall back to the host's gcc. Switching `=` to `?=` honors a compiler passed in by the environment or command line, and keeps the old default when none is given. The sibling libraries libgbinder and libdbusaccess already do this.

I found this while cross-compiling libgbinder-radio with Yocto/OpenEmbedded for a 32-bit ARM AsteroidOS watch port: OpenEmbedded exports CC for the target toolchain but does not set CROSS_COMPILE, so `CC = $(CROSS_COMPILE)gcc` resolved to the host gcc and the build failed with a glib pointer-size static assert (host/target mismatch).