### PR TITLE
Mark clients without rilConnected as connected

### DIFF
--- a/include/radio_client.h
+++ b/include/radio_client.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2026 Jolla Mobile Ltd
  * Copyright (C) 2021 Jolla Ltd.
  * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
  *
@@ -81,6 +82,21 @@ radio_client_aidl_interface(
 const char*
 radio_client_slot(
     RadioClient* client);
+
+const char*
+radio_client_req_name(
+    RadioClient* client,
+    RADIO_REQ req); /* Since 1.6.5 */
+
+const char*
+radio_client_resp_name(
+    RadioClient* client,
+    RADIO_RESP resp); /* Since 1.6.5 */
+
+const char*
+radio_client_ind_name(
+    RadioClient* client,
+    RADIO_IND ind); /* Since 1.6.5 */
 
 gboolean
 radio_client_dead(

--- a/src/radio_client.c
+++ b/src/radio_client.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2026 Jolla Mobile Ltd
  * Copyright (C) 2021-2022 Jolla Ltd.
  * Copyright (C) 2021-2022 Slava Monich <slava.monich@jolla.com>
  *
@@ -258,6 +259,30 @@ radio_client_slot(
     RadioClient* self)
 {
     return G_LIKELY(self) ? self->instance->slot : NULL;
+}
+
+const char*
+radio_client_req_name(
+    RadioClient* self,
+    RADIO_REQ req) /* Since 1.6.5 */
+{
+    return radio_req_name2(self ? self->instance : NULL, req);
+}
+
+const char*
+radio_client_resp_name(
+    RadioClient* self,
+    RADIO_RESP resp) /* Since 1.6.5 */
+{
+    return radio_resp_name2(self ? self->instance : NULL, resp);
+}
+
+const char*
+radio_client_ind_name(
+    RadioClient* self,
+    RADIO_IND ind) /* Since 1.6.5 */
+{
+    return radio_ind_name2(self ? self->instance : NULL, ind);
 }
 
 gboolean

--- a/src/radio_config.c
+++ b/src/radio_config.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2026 Jolla Mobile Ltd
  * Copyright (C) 2022 Jolla Ltd.
  * Copyright (C) 2022 Slava Monich <slava.monich@jolla.com>
  *
@@ -42,28 +43,29 @@
 
 #include <gbinder.h>
 
-#include <gutil_idlepool.h>
 #include <gutil_macros.h>
 #include <gutil_misc.h>
 #include <gutil_strv.h>
 
 /* This API exists since 1.4.6 */
 
-typedef struct radio_config {
+typedef struct radio_config_interface_desc RadioConfigInterfaceDesc;
+typedef struct radio_config RadioConfig;
+
+struct radio_config {
     RadioBase base;
-    GUtilIdlePool* pool;
+    const RadioConfigInterfaceDesc* desc;
+    RadioConfig** shared;
     GBinderClient* client;
     GBinderRemoteObject* remote;
     GBinderLocalObject* response;
     GBinderLocalObject* indication;
-    RADIO_INTERFACE_TYPE interface_type;
-    RADIO_CONFIG_INTERFACE version;
     GHashTable* req_quarks;
     GHashTable* resp_quarks;
     GHashTable* ind_quarks;
     gulong death_id;
     gboolean dead;
-} RadioConfig;
+};
 
 typedef RadioBaseClass RadioConfigClass;
 GType radio_config_get_type() RADIO_INTERNAL;
@@ -160,48 +162,6 @@ static const char* const radio_config_aidl_response_ifaces[] = {
 G_STATIC_ASSERT(G_N_ELEMENTS(radio_config_aidl_response_ifaces) ==
     RADIO_CONFIG_AIDL_INTERFACE_COUNT + 1);
 
-typedef struct radio_config_interface_desc {
-    RADIO_INTERFACE_TYPE interface_type;
-    RADIO_CONFIG_INTERFACE version;
-    const char* fqname;
-    const char* radio_iface;
-    const char* const* ind_ifaces;
-    const char* const* resp_ifaces;
-} RadioConfigInterfaceDesc;
-
-#define RADIO_CONFIG_INTERFACE_INDEX(x) (RADIO_CONFIG_INTERFACE_COUNT - x - 1)
-
-#define RADIO_CONFIG_INTERFACE_DESC(v) \
-        RADIO_INTERFACE_TYPE_HIDL, \
-        RADIO_CONFIG_INTERFACE_##v, \
-        RADIO_CONFIG_##v##_FQNAME, \
-        RADIO_CONFIG_##v, \
-        radio_config_indication_ifaces + \
-        RADIO_CONFIG_INTERFACE_INDEX(RADIO_CONFIG_INTERFACE_##v), \
-        radio_config_response_ifaces + \
-        RADIO_CONFIG_INTERFACE_INDEX(RADIO_CONFIG_INTERFACE_##v)
-
-static const RadioConfigInterfaceDesc radio_config_interfaces[] = {
-   { RADIO_CONFIG_INTERFACE_DESC(1_2) },
-   { RADIO_CONFIG_INTERFACE_DESC(1_1) },
-   { RADIO_CONFIG_INTERFACE_DESC(1_0) }
-};
-G_STATIC_ASSERT(G_N_ELEMENTS(radio_config_interfaces) ==
-    RADIO_CONFIG_INTERFACE_COUNT);
-
-static const RadioConfigInterfaceDesc radio_config_aidl_interfaces[] = {
-    {
-        RADIO_INTERFACE_TYPE_AIDL,
-        RADIO_CONFIG_AIDL_INTERFACE_1,
-        RADIO_CONFIG_AIDL_FQNAME,
-        RADIO_CONFIG_AIDL,
-        radio_config_aidl_indication_ifaces,
-        radio_config_aidl_response_ifaces,
-    }
-};
-G_STATIC_ASSERT(G_N_ELEMENTS(radio_config_aidl_interfaces) ==
-    RADIO_CONFIG_AIDL_INTERFACE_COUNT);
-
 /* Must have a separate instance for each interface version */
 static RadioConfig* radio_config_instance[RADIO_CONFIG_INTERFACE_COUNT] =
     { NULL };
@@ -213,6 +173,186 @@ typedef struct radio_config_call {
     RadioBaseRequestSentFunc callback;
     RadioBase* object;
 } RadioConfigCall;
+
+/*==========================================================================*
+ * HIDL API flavor
+ *==========================================================================*/
+
+typedef struct radio_config_interface_desc {
+    const char* api_name;
+    RADIO_INTERFACE_TYPE interface_type;
+    RADIO_CONFIG_INTERFACE version;
+    const char* fqname;
+    const char* radio_iface;
+    const char* const* ind_ifaces;
+    const char* const* resp_ifaces;
+    const GBinderClientIfaceInfo* iface_info;
+    guint iface_info_count;
+    GBINDER_STABILITY_LEVEL stability;
+    const RadioResponseInfo* (*read_response_info)(GBinderReader* reader);
+    const char* (*req_name)(guint req);
+    const char* (*resp_name)(guint req);
+    const char* (*ind_name)(guint req);
+    guint set_response_functions_req;
+} RadioConfigInterfaceDesc;
+
+static
+const char*
+radio_config_req_name_hidl(
+    guint req)
+{
+    switch ((RADIO_CONFIG_REQ)req) {
+    case RADIO_CONFIG_REQ_SET_RESPONSE_FUNCTIONS: return "setResponseFunctions";
+    #define RADIO_CONFIG_REQ_(req,resp,Name,NAME)\
+    case RADIO_CONFIG_REQ_##NAME: return #Name;
+    RADIO_CONFIG_CALL_1_0(RADIO_CONFIG_REQ_)
+    RADIO_CONFIG_CALL_1_1(RADIO_CONFIG_REQ_)
+    /* 1.2 defines no new requests */
+    #undef RADIO_CONFIG_REQ_
+    case RADIO_CONFIG_REQ_ANY:
+        break;
+    }
+    return NULL;
+}
+
+static
+const char*
+radio_config_resp_name_hidl(
+    guint resp)
+{
+    switch ((RADIO_CONFIG_RESP)resp) {
+    #define RADIO_CONFIG_RESP_(req,resp,Name,NAME) \
+    case RADIO_CONFIG_RESP_##NAME: return #Name "Response";
+    RADIO_CONFIG_CALL_1_0(RADIO_CONFIG_RESP_)
+    RADIO_CONFIG_CALL_1_1(RADIO_CONFIG_RESP_)
+    #undef RADIO_CONFIG_RESP_
+    case RADIO_CONFIG_RESP_GET_SIM_SLOTS_STATUS_1_2:
+        return "getSimSlotsStatusResponse_1_2";
+    case RADIO_CONFIG_RESP_ANY:
+        break;
+    }
+    return NULL;
+}
+
+static
+const char*
+radio_config_ind_name_hidl(
+    guint ind)
+{
+    switch ((RADIO_CONFIG_IND)ind) {
+    #define RADIO_CONFIG_IND_(code,Name,NAME) \
+    case RADIO_CONFIG_IND_##NAME: return #Name;
+    RADIO_CONFIG_IND_1_0(RADIO_CONFIG_IND_)
+    /* 1.1 defines no new indications */
+    RADIO_CONFIG_IND_1_2(RADIO_CONFIG_IND_)
+    #undef RADIO_CONFIG_IND_
+    case RADIO_CONFIG_IND_ANY:
+        break;
+    }
+    return NULL;
+}
+
+#define RADIO_CONFIG_INTERFACE_INDEX(x) (RADIO_CONFIG_INTERFACE_COUNT - x - 1)
+#define RADIO_CONFIG_INTERFACE_DESC(v) \
+        "hidl_" #v, \
+        RADIO_INTERFACE_TYPE_HIDL, \
+        RADIO_CONFIG_INTERFACE_##v, \
+        RADIO_CONFIG_##v##_FQNAME, \
+        RADIO_CONFIG_##v, \
+        radio_config_indication_ifaces + \
+        RADIO_CONFIG_INTERFACE_INDEX(RADIO_CONFIG_INTERFACE_##v), \
+        radio_config_response_ifaces + \
+        RADIO_CONFIG_INTERFACE_INDEX(RADIO_CONFIG_INTERFACE_##v),   \
+        radio_config_iface_info, G_N_ELEMENTS(radio_config_iface_info), \
+        GBINDER_STABILITY_SYSTEM, \
+        radio_read_response_info_hidl, \
+        radio_config_req_name_hidl, \
+        radio_config_resp_name_hidl, \
+        radio_config_ind_name_hidl, \
+        RADIO_CONFIG_REQ_SET_RESPONSE_FUNCTIONS
+
+static const RadioConfigInterfaceDesc radio_config_interfaces[] = {
+   { RADIO_CONFIG_INTERFACE_DESC(1_2) },
+   { RADIO_CONFIG_INTERFACE_DESC(1_1) },
+   { RADIO_CONFIG_INTERFACE_DESC(1_0) }
+};
+G_STATIC_ASSERT(G_N_ELEMENTS(radio_config_interfaces) ==
+    RADIO_CONFIG_INTERFACE_COUNT);
+
+/*==========================================================================*
+ * AIDL API flavor
+ *==========================================================================*/
+
+static
+const char*
+radio_config_req_name_aidl(
+    guint req)
+{
+    switch ((RADIO_CONFIG_AIDL_REQ)req) {
+    case RADIO_CONFIG_AIDL_REQ_SET_RESPONSE_FUNCTIONS: return "setResponseFunctions";
+    #define RADIO_CONFIG_AIDL_REQ_(req,resp,Name,NAME) \
+    case RADIO_CONFIG_AIDL_REQ_##NAME: return #Name;
+    RADIO_CONFIG_AIDL_CALL_1(RADIO_CONFIG_AIDL_REQ_)
+    #undef RADIO_CONFIG_AIDL_REQ_
+    case RADIO_CONFIG_AIDL_REQ_ANY:
+        break;
+    }
+    return NULL;
+}
+
+static
+const char*
+radio_config_resp_name_aidl(
+    guint resp)
+{
+    switch ((RADIO_CONFIG_AIDL_RESP)resp) {
+    #define RADIO_CONFIG_AIDL_RESP_(req,resp,Name,NAME) \
+    case RADIO_CONFIG_AIDL_RESP_##NAME: return #Name "Response";
+    RADIO_CONFIG_AIDL_CALL_1(RADIO_CONFIG_AIDL_RESP_)
+    #undef RADIO_CONFIG_AIDL_RESP_
+    case RADIO_CONFIG_AIDL_RESP_ANY:
+        break;
+    }
+    return NULL;
+}
+
+static
+const char*
+radio_config_ind_name_aidl(
+    guint ind)
+{
+    switch ((RADIO_CONFIG_AIDL_IND)ind) {
+    #define RADIO_CONFIG_AIDL_IND_(code,Name,NAME) \
+    case RADIO_CONFIG_AIDL_IND_##NAME: return #Name;
+    RADIO_CONFIG_AIDL_IND_1(RADIO_CONFIG_AIDL_IND_)
+    #undef RADIO_CONFIG_AIDL_IND_
+    case RADIO_CONFIG_AIDL_IND_ANY:
+        break;
+    }
+    return NULL;
+}
+
+static const RadioConfigInterfaceDesc radio_config_aidl_interfaces[] = {
+    {
+        "aidl",
+        RADIO_INTERFACE_TYPE_AIDL,
+        RADIO_CONFIG_AIDL_INTERFACE_1,
+        RADIO_CONFIG_AIDL_FQNAME,
+        RADIO_CONFIG_AIDL,
+        radio_config_aidl_indication_ifaces,
+        radio_config_aidl_response_ifaces,
+        radio_config_aidl_iface_info,
+        G_N_ELEMENTS(radio_config_aidl_iface_info),
+        GBINDER_STABILITY_VINTF,
+        radio_read_response_info_aidl,
+        radio_config_req_name_aidl,
+        radio_config_resp_name_aidl,
+        radio_config_ind_name_aidl,
+        RADIO_CONFIG_AIDL_REQ_SET_RESPONSE_FUNCTIONS
+    }
+};
+G_STATIC_ASSERT(G_N_ELEMENTS(radio_config_aidl_interfaces) ==
+    RADIO_CONFIG_AIDL_INTERFACE_COUNT);
 
 /*==========================================================================*
  * Implementation
@@ -241,96 +381,33 @@ radio_config_call_complete(
 }
 
 static
-const char*
-radio_config_known_req_name(
-    RadioConfig* self,
-    RADIO_CONFIG_REQ req)
+GQuark
+radio_config_quark(
+    guint code,
+    GHashTable* quarks,
+    const char* (*known_name)(guint code))
 {
-    if (!G_LIKELY(self) || self->interface_type == RADIO_INTERFACE_TYPE_HIDL) {
-        switch (req) {
-        case RADIO_CONFIG_REQ_SET_RESPONSE_FUNCTIONS: return "setResponseFunctions";
-#define RADIO_CONFIG_REQ_(req,resp,Name,NAME) \
-        case RADIO_CONFIG_REQ_##NAME: return #Name;
-        RADIO_CONFIG_CALL_1_0(RADIO_CONFIG_REQ_)
-        RADIO_CONFIG_CALL_1_1(RADIO_CONFIG_REQ_)
-        /* 1.2 defines no new requests */
-#undef RADIO_CONFIG_REQ_
-        case RADIO_CONFIG_REQ_ANY:
-            break;
-        }
-    } else if (self->interface_type == RADIO_INTERFACE_TYPE_AIDL) {
-        switch ((RADIO_CONFIG_AIDL_REQ)req) {
-        case RADIO_CONFIG_AIDL_REQ_SET_RESPONSE_FUNCTIONS: return "setResponseFunctions";
-#define RADIO_CONFIG_AIDL_REQ_(req,resp,Name,NAME) \
-        case RADIO_CONFIG_AIDL_REQ_##NAME: return #Name;
-        RADIO_CONFIG_AIDL_CALL_1(RADIO_CONFIG_AIDL_REQ_)
-#undef RADIO_CONFIG_AIDL_REQ_
-        case RADIO_CONFIG_AIDL_REQ_ANY:
-            break;
-        }
-    }
-    return NULL;
-}
+    GQuark q = 0;
 
-static
-const char*
-radio_config_known_resp_name(
-    RadioConfig* self,
-    RADIO_CONFIG_RESP resp)
-{
-    if (!G_LIKELY(self) || self->interface_type == RADIO_INTERFACE_TYPE_HIDL) {
-        switch (resp) {
-#define RADIO_CONFIG_RESP_(req,resp,Name,NAME) \
-        case RADIO_CONFIG_RESP_##NAME: return #Name "Response";
-        RADIO_CONFIG_CALL_1_0(RADIO_CONFIG_RESP_)
-        RADIO_CONFIG_CALL_1_1(RADIO_CONFIG_RESP_)
-#undef RADIO_CONFIG_RESP_
-        case RADIO_CONFIG_RESP_GET_SIM_SLOTS_STATUS_1_2:
-            return "getSimSlotsStatusResponse_1_2";
-        case RADIO_CONFIG_RESP_ANY:
-            break;
-        }
-    } else if (self->interface_type == RADIO_INTERFACE_TYPE_AIDL) {
-        switch ((RADIO_CONFIG_AIDL_RESP)resp) {
-#define RADIO_CONFIG_AIDL_RESP_(req,resp,Name,NAME) \
-        case RADIO_CONFIG_AIDL_RESP_##NAME: return #Name "Response";
-        RADIO_CONFIG_AIDL_CALL_1(RADIO_CONFIG_AIDL_RESP_)
-#undef RADIO_CONFIG_AIDL_RESP_
-        case RADIO_CONFIG_AIDL_RESP_ANY:
-            break;
-        }
-    }
-    return NULL;
-}
+    if (code) {
+        gpointer key = GUINT_TO_POINTER(code);
 
-static
-const char*
-radio_config_known_ind_name(
-    RadioConfig* self,
-    RADIO_CONFIG_IND ind)
-{
-    if (!G_LIKELY(self) || self->interface_type == RADIO_INTERFACE_TYPE_HIDL) {
-        switch (ind) {
-#define RADIO_CONFIG_IND_(code,Name,NAME) \
-        case RADIO_CONFIG_IND_##NAME: return #Name;
-        RADIO_CONFIG_IND_1_0(RADIO_CONFIG_IND_)
-        /* 1.1 defines no new indications */
-        RADIO_CONFIG_IND_1_2(RADIO_CONFIG_IND_)
-#undef RADIO_CONFIG_IND_
-        case RADIO_CONFIG_IND_ANY:
-            break;
-        }
-    } else if (self->interface_type == RADIO_INTERFACE_TYPE_AIDL) {
-        switch ((RADIO_CONFIG_AIDL_IND)ind) {
-#define RADIO_CONFIG_AIDL_IND_(code,Name,NAME) \
-        case RADIO_CONFIG_AIDL_IND_##NAME: return #Name;
-        RADIO_CONFIG_AIDL_IND_1(RADIO_CONFIG_AIDL_IND_)
-#undef RADIO_CONFIG_AIDL_IND_
-        case RADIO_CONFIG_AIDL_IND_ANY:
-            break;
+        q = GPOINTER_TO_UINT(g_hash_table_lookup(quarks, key));
+        if (!q) {
+            const char* known = known_name(code);
+
+            if (known) {
+                q = g_quark_from_static_string(known);
+            } else {
+                char* str = g_strdup_printf("%u", code);
+
+                q = g_quark_from_string(str);
+                g_free(str);
+            }
+            g_hash_table_insert(quarks, key, GUINT_TO_POINTER(q));
         }
     }
-    return NULL;
+    return q;
 }
 
 static
@@ -339,24 +416,7 @@ radio_config_req_quark(
     RadioConfig* self,
     RADIO_CONFIG_REQ req)
 {
-    GQuark q = 0;
-
-    if (req != RADIO_CONFIG_REQ_ANY) {
-        gpointer key = GUINT_TO_POINTER(req);
-
-        q = GPOINTER_TO_UINT(g_hash_table_lookup(self->req_quarks, key));
-        if (!q) {
-            const char* known = radio_config_known_req_name(self, req);
-
-            if (known) {
-                q = g_quark_from_static_string(known);
-            } else {
-                q = g_quark_from_string(radio_config_req_name(self, req));
-            }
-            g_hash_table_insert(self->req_quarks, key, GUINT_TO_POINTER(q));
-        }
-    }
-    return q;
+    return radio_config_quark(req, self->req_quarks, self->desc->req_name);
 }
 
 static
@@ -365,24 +425,7 @@ radio_config_resp_quark(
     RadioConfig* self,
     RADIO_CONFIG_RESP resp)
 {
-    GQuark q = 0;
-
-    if (resp != RADIO_CONFIG_RESP_ANY) {
-        gpointer key = GUINT_TO_POINTER(resp);
-
-        q = GPOINTER_TO_UINT(g_hash_table_lookup(self->resp_quarks, key));
-        if (!q) {
-            const char* known = radio_config_known_resp_name(self, resp);
-
-            if (known) {
-                q = g_quark_from_static_string(known);
-            } else {
-                q = g_quark_from_string(radio_config_resp_name(self, resp));
-            }
-            g_hash_table_insert(self->resp_quarks, key, GUINT_TO_POINTER(q));
-        }
-    }
-    return q;
+    return radio_config_quark(resp, self->resp_quarks, self->desc->resp_name);
 }
 
 static
@@ -391,24 +434,7 @@ radio_config_ind_quark(
     RadioConfig* self,
     RADIO_CONFIG_IND ind)
 {
-    GQuark q = 0;
-
-    if (ind != RADIO_CONFIG_IND_ANY) {
-        gpointer key = GUINT_TO_POINTER(ind);
-
-        q = GPOINTER_TO_UINT(g_hash_table_lookup(self->ind_quarks, key));
-        if (!q) {
-            const char* known = radio_config_known_ind_name(self, ind);
-
-            if (known) {
-                q = g_quark_from_static_string(known);
-            } else {
-                q = g_quark_from_string(radio_config_ind_name(self, ind));
-            }
-            g_hash_table_insert(self->ind_quarks, key, GUINT_TO_POINTER(q));
-        }
-    }
-    return q;
+    return radio_config_quark(ind, self->ind_quarks, self->desc->ind_name);
 }
 
 static
@@ -467,26 +493,21 @@ radio_config_response(
     void* user_data)
 {
     RadioConfig* self = THIS(user_data);
+    const RadioConfigInterfaceDesc* desc = self->desc;
     const char* iface = gbinder_remote_request_interface(req);
     const RadioResponseInfo* info = NULL;
     GBinderReader args;
 
     gbinder_remote_request_init_reader(req, &args);
-
-    if (gutil_strv_contains((GStrV*)radio_config_response_ifaces, iface)) {
+    if (gutil_strv_contains((GStrV*)desc->resp_ifaces, iface)) {
         /* All responses must be one-way and have RadioResponseInfo */
-        info = gbinder_reader_read_hidl_struct(&args, RadioResponseInfo);
-    } else if (gutil_strv_contains((GStrV*)radio_config_aidl_response_ifaces, iface)) {
-        /* RadioResponseInfo has the same fields/padding between HIDL and AIDL */
-        gsize out_size;
-        info = gbinder_reader_read_parcelable(&args, &out_size);
-        GASSERT(out_size == sizeof(RadioResponseInfo));
+        GASSERT(flags & GBINDER_TX_FLAG_ONEWAY);
+        info = desc->read_response_info(&args);
     } else {
-        GDEBUG("radio_config_response called on unknown interface %s", iface);
+        GWARN("Unexpected response %s %u", iface, code);
+        *status = GBINDER_STATUS_FAILED;
         return NULL;
     }
-
-    GASSERT(flags & GBINDER_TX_FLAG_ONEWAY);
 
     if (info) {
         int p = RADIO_OBSERVER_PRIORITY_HIGHEST;
@@ -507,7 +528,7 @@ radio_config_response(
 
         /* Then the response is actually processed */
         if (!radio_base_handle_resp(&self->base, code, info, &args)) {
-            const char* name = radio_config_known_resp_name(self, code);
+            const char* name = desc->resp_name(code);
 
             /* Most likely this is a response to a cancelled request */
             GDEBUG("Ignoring IRadioConfig response [%08x] %u %s",
@@ -552,26 +573,6 @@ radio_config_drop_binder(
 
 static
 void
-radio_config_died(
-    GBinderRemoteObject* obj,
-    void* user_data)
-{
-    RadioConfig* self = THIS(user_data);
-
-    GWARN("IRadioConfig died");
-    self->dead = TRUE;
-    radio_config_ref(self);
-    radio_config_drop_binder(self);
-    if (radio_config_instance[self->version] == self) {
-        radio_config_instance[self->version] = NULL; /* Clear the cache */
-    }
-    g_signal_emit(self, radio_config_signals[SIGNAL_DEATH], 0);
-    radio_base_handle_death(&self->base);
-    radio_config_unref(self);
-}
-
-static
-void
 radio_config_gone(
     gpointer user_data,
     GObject* dead)
@@ -585,6 +586,28 @@ radio_config_gone(
 }
 
 static
+void
+radio_config_died(
+    GBinderRemoteObject* obj,
+    void* user_data)
+{
+    RadioConfig* self = THIS(user_data);
+
+    GWARN("IRadioConfig died");
+    self->dead = TRUE;
+    radio_config_ref(self);
+    radio_config_drop_binder(self);
+    if (self->shared && *self->shared == self) {
+        /* Clear the cache */
+        g_object_weak_unref(G_OBJECT(self), radio_config_gone, self->shared);
+        *self->shared = NULL;
+    }
+    g_signal_emit(self, radio_config_signals[SIGNAL_DEATH], 0);
+    radio_base_handle_death(&self->base);
+    radio_config_unref(self);
+}
+
+static
 RadioConfig*
 radio_config_create(
     GBinderServiceManager* sm,
@@ -595,11 +618,10 @@ radio_config_create(
     GBinderLocalRequest* req;
     GBinderWriter writer;
     int status;
-    guint req_code = RADIO_CONFIG_REQ_NONE;
 
+    GDEBUG("Using %s config api", desc->api_name);
     radio_base_initialize(&self->base);
-    self->interface_type = desc->interface_type;
-    self->version = desc->version;
+    self->desc = desc;
     self->remote = gbinder_remote_object_ref(remote);
     self->indication = gbinder_servicemanager_new_local_object2(sm,
         desc->ind_ifaces, radio_config_indication, self);
@@ -607,29 +629,28 @@ radio_config_create(
         desc->resp_ifaces, radio_config_response, self);
     self->death_id = gbinder_remote_object_add_death_handler(remote,
         radio_config_died, self);
+    self->client = gbinder_client_new2(remote, desc->iface_info,
+        desc->iface_info_count);
 
-    if (self->interface_type == RADIO_INTERFACE_TYPE_HIDL) {
-        self->client = gbinder_client_new2(remote, radio_config_iface_info,
-            G_N_ELEMENTS(radio_config_iface_info));
-        req_code = RADIO_CONFIG_REQ_SET_RESPONSE_FUNCTIONS;
-    } else if (self->interface_type == RADIO_INTERFACE_TYPE_AIDL) {
-        self->client = gbinder_client_new2(remote, radio_config_aidl_iface_info,
-            G_N_ELEMENTS(radio_config_aidl_iface_info));
-        req_code = RADIO_CONFIG_AIDL_REQ_SET_RESPONSE_FUNCTIONS;
+    gbinder_local_object_set_stability(self->indication, desc->stability);
+    gbinder_local_object_set_stability(self->response, desc->stability);
 
-        gbinder_local_object_set_stability(self->indication, GBINDER_STABILITY_VINTF);
-        gbinder_local_object_set_stability(self->response, GBINDER_STABILITY_VINTF);
-    }
-    GASSERT(self->client);
-
-    /* IRadioConfig::setResponseFunctions */
+    /*
+     * IRadioConfig.hal:
+     * setResponseFunctions(IRadioConfigResponse radioConfigResponse,
+     *     IRadioConfigIndication radioConfigIndication);
+     *
+     * IRadioConfig.aidl:
+     * void setResponseFunctions(in IRadioConfigResponse radioConfigResponse,
+     *     in IRadioConfigIndication radioConfigIndication);
+     */
     req = gbinder_client_new_request2(self->client,
-        req_code);
+        desc->set_response_functions_req);
     gbinder_local_request_init_writer(req, &writer);
     gbinder_writer_append_local_object(&writer, self->response);
     gbinder_writer_append_local_object(&writer, self->indication);
     gbinder_remote_reply_unref(gbinder_client_transact_sync_reply(self->client,
-        req_code, req, &status));
+        desc->set_response_functions_req, req, &status));
     GVERBOSE_("IRadioConfig::setResponseFunctions status %d", status);
     gbinder_local_request_unref(req);
     return self;
@@ -671,20 +692,18 @@ radio_config_new_with_version_and_interface_type(
         } else if (max_version > RADIO_CONFIG_INTERFACE_MAX) {
             max_version = RADIO_CONFIG_INTERFACE_MAX;
         }
-
         instances = radio_config_instance;
         interfaces = radio_config_interfaces;
         num_interfaces = G_N_ELEMENTS(radio_config_interfaces);
     } else if (interface_type == RADIO_INTERFACE_TYPE_AIDL) {
         /* Only RADIO_CONFIG_AIDL_INTERFACE_1 is supported for now */
         max_version = RADIO_CONFIG_AIDL_INTERFACE_1;
-
         binder_device = GBINDER_DEFAULT_BINDER;
         instances = radio_config_aidl_instance;
         interfaces = radio_config_aidl_interfaces;
         num_interfaces = G_N_ELEMENTS(radio_config_aidl_interfaces);
     } else {
-        GINFO("Wrong interface_type %d (neither HIDL nor AIDL)", interface_type);
+        GWARN("Wrong interface_type %d (neither HIDL nor AIDL)", interface_type);
         return NULL;
     }
 
@@ -726,9 +745,9 @@ radio_config_new_with_version_and_interface_type(
 
             gbinder_servicemanager_unref(sm);
             if (config) {
-                instances[desc->version] = config;
+                *(config->shared = instances + desc->version) = config;
                 g_object_weak_ref(G_OBJECT(config), radio_config_gone,
-                    instances + desc->version);
+                    config->shared);
                 return config;
             }
         }
@@ -766,14 +785,14 @@ RADIO_INTERFACE_TYPE
 radio_config_interface_type(
     RadioConfig* self)
 {
-    return G_LIKELY(self) ? self->interface_type : RADIO_INTERFACE_TYPE_NONE;
+    return self ? self->desc->interface_type : RADIO_INTERFACE_TYPE_NONE;
 }
 
 RADIO_CONFIG_INTERFACE
 radio_config_interface(
     RadioConfig* self)
 {
-    return G_LIKELY(self) ? self->version : RADIO_CONFIG_INTERFACE_NONE;
+    return self ? self->desc->version : RADIO_CONFIG_INTERFACE_NONE;
 }
 
 gsize
@@ -796,18 +815,7 @@ radio_config_req_name(
     RadioConfig* self,
     RADIO_CONFIG_REQ req)
 {
-    const char* known = radio_config_known_req_name(self, req);
-
-    if (known) {
-        return known;
-    } else if (G_LIKELY(self)) {
-        char* str = g_strdup_printf("%u", (guint)req);
-
-        gutil_idle_pool_add(self->pool, str, g_free);
-        return str;
-    } else {
-        return NULL;
-    }
+    return G_LIKELY(self) ? self->desc->req_name(req) : NULL;
 }
 
 const char*
@@ -815,18 +823,7 @@ radio_config_resp_name(
     RadioConfig* self,
     RADIO_CONFIG_RESP resp)
 {
-    const char* known = radio_config_known_resp_name(self, resp);
-
-    if (known) {
-        return known;
-    } else if (G_LIKELY(self)) {
-        char* str = g_strdup_printf("%u", (guint)resp);
-
-        gutil_idle_pool_add(self->pool, str, g_free);
-        return str;
-    } else {
-        return NULL;
-    }
+    return G_LIKELY(self) ? self->desc->resp_name(resp) : NULL;
 }
 
 const char*
@@ -834,18 +831,7 @@ radio_config_ind_name(
     RadioConfig* self,
     RADIO_CONFIG_IND ind)
 {
-    const char* known = radio_config_known_ind_name(self, ind);
-
-    if (known) {
-        return known;
-    } else if (G_LIKELY(self)) {
-        char* str = g_strdup_printf("%u", (guint)ind);
-
-        gutil_idle_pool_add(self->pool, str, g_free);
-        return str;
-    } else {
-        return NULL;
-    }
+    return G_LIKELY(self) ? self->desc->ind_name(ind) : NULL;
 }
 
 gulong
@@ -1087,8 +1073,6 @@ void
 radio_config_init(
     RadioConfig* self)
 {
-    self->version = RADIO_CONFIG_INTERFACE_NONE;
-    self->pool = gutil_idle_pool_new();
     self->req_quarks = g_hash_table_new(g_direct_hash, g_direct_equal);
     self->resp_quarks = g_hash_table_new(g_direct_hash, g_direct_equal);
     self->ind_quarks = g_hash_table_new(g_direct_hash, g_direct_equal);
@@ -1103,7 +1087,6 @@ radio_config_finalize(
 
     radio_config_drop_binder(self);
     gbinder_client_unref(self->client);
-    gutil_idle_pool_destroy(self->pool);
     g_hash_table_destroy(self->req_quarks);
     g_hash_table_destroy(self->resp_quarks);
     g_hash_table_destroy(self->ind_quarks);

--- a/src/radio_instance.c
+++ b/src/radio_instance.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Jolla Mobile Ltd
+ * Copyright (C) 2025-2026 Jolla Mobile Ltd
  * Copyright (C) 2018-2025 Slava Monich <slava@monich.com>
  * Copyright (C) 2018-2022 Jolla Ltd.
  *
@@ -160,207 +160,103 @@ G_STATIC_ASSERT(G_N_ELEMENTS(radio_response_ifaces) == RADIO_INTERFACE_COUNT + 1
 
 struct radio_interface_desc {
     RADIO_INTERFACE version;
+    RADIO_INTERFACE_TYPE interface_type;
     RADIO_AIDL_INTERFACE aidl_interface;
     const char* radio_iface;
     const char* const* ind_ifaces;
     const char* const* resp_ifaces;
+    const GBinderClientIfaceInfo* iface_info;
+    guint iface_info_count;
+    GBINDER_STABILITY_LEVEL stability;
     const RadioResponseInfo* (*read_response_info)(GBinderReader* reader);
-    gint32 set_response_functions_req;
-    gint32 ack_req;
-    gint32 resp_ack_req;
+    guint set_response_functions_req;
+    guint ack_req;
+    guint resp_ack_req;
+    guint ril_connected_ind;
 };
-
-static
-const RadioResponseInfo*
-radio_instance_read_hidl_response_info(
-    GBinderReader* reader);
-
-static
-const RadioResponseInfo*
-radio_instance_read_aidl_response_info(
-    GBinderReader* reader);
 
 #define RADIO_INTERFACE_INDEX(x) (RADIO_INTERFACE_COUNT - x - 1)
 
 #define RADIO_INTERFACE_DESC(v) \
         RADIO_INTERFACE_##v, \
+        RADIO_INTERFACE_TYPE_HIDL, \
         RADIO_AIDL_INTERFACE_NONE, \
         RADIO_##v, \
         radio_indication_ifaces + RADIO_INTERFACE_INDEX(RADIO_INTERFACE_##v), \
         radio_response_ifaces + RADIO_INTERFACE_INDEX(RADIO_INTERFACE_##v), \
-        radio_instance_read_hidl_response_info, \
+        radio_iface_info, G_N_ELEMENTS(radio_iface_info), \
+        GBINDER_STABILITY_SYSTEM, \
+        radio_read_response_info_hidl, \
         RADIO_REQ_SET_RESPONSE_FUNCTIONS, \
         RADIO_REQ_RESPONSE_ACKNOWLEDGEMENT, \
-        RADIO_RESP_ACKNOWLEDGE_REQUEST
+        RADIO_RESP_ACKNOWLEDGE_REQUEST, \
+        RADIO_IND_RIL_CONNECTED
 
 static const RadioInterfaceDesc radio_hidl_interfaces[] = {
-   { RADIO_INTERFACE_DESC(1_5) },
-   { RADIO_INTERFACE_DESC(1_4) },
-   { RADIO_INTERFACE_DESC(1_3) },
-   { RADIO_INTERFACE_DESC(1_2) },
-   { RADIO_INTERFACE_DESC(1_1) },
-   { RADIO_INTERFACE_DESC(1_0) }
+    { RADIO_INTERFACE_DESC(1_5) },
+    { RADIO_INTERFACE_DESC(1_4) },
+    { RADIO_INTERFACE_DESC(1_3) },
+    { RADIO_INTERFACE_DESC(1_2) },
+    { RADIO_INTERFACE_DESC(1_1) },
+    { RADIO_INTERFACE_DESC(1_0) }
 };
 G_STATIC_ASSERT(G_N_ELEMENTS(radio_hidl_interfaces) == RADIO_INTERFACE_COUNT);
 
+/* The order of these must match the RADIO_AIDL_INTERFACE enum */
+#define AIDL_INTERFACES(i) \
+    i(DATA) i(IMS) i(MESSAGING) i(MODEM) i(NETWORK) i(SIM) i(VOICE)
+
 static const GBinderClientIfaceInfo radio_aidl_iface_info[] = {
-    {RADIO_DATA, RADIO_DATA_1_REQ_LAST},
-    {RADIO_IMS, RADIO_IMS_1_REQ_LAST},
-    {RADIO_MESSAGING, RADIO_MESSAGING_1_REQ_LAST},
-    {RADIO_MODEM, RADIO_MODEM_1_REQ_LAST},
-    {RADIO_NETWORK, RADIO_NETWORK_1_REQ_LAST},
-    {RADIO_SIM, RADIO_SIM_1_REQ_LAST},
-    {RADIO_VOICE, RADIO_VOICE_1_REQ_LAST},
+    #define AIDL_IFACE_INFO(x) { RADIO_##x, RADIO_##x##_1_REQ_LAST },
+    AIDL_INTERFACES(AIDL_IFACE_INFO)
+    #undef AIDL_IFACE_INFO
 };
 
-static const char* const radio_data_indication_ifaces[] = {
-    RADIO_DATA_INDICATION,
-    NULL
+static const char* const radio_aidl_indication_ifaces[] = {
+    #define AIDL_INDICATION_IFACE(x) RADIO_##x##_INDICATION, NULL,
+    AIDL_INTERFACES(AIDL_INDICATION_IFACE)
+    #undef AIDL_INDICATION_IFACE
 };
 
-static const char* const radio_data_response_ifaces[] = {
-    RADIO_DATA_RESPONSE,
-    NULL
+static const char* const radio_aidl_response_ifaces[] = {
+    #define AIDL_RESPONSE_IFACE(x) RADIO_##x##_RESPONSE, NULL,
+    AIDL_INTERFACES(AIDL_RESPONSE_IFACE)
+    #undef AIDL_RESPONSE_IFACE
 };
 
-static const char* const radio_ims_indication_ifaces[] = {
-    RADIO_IMS_INDICATION,
-    NULL
-};
+#define AIDL_INTERFACE_DESC_(TYPE,respAckReq,ackReqResp,rilConnectedInd) \
+        RADIO_INTERFACE_NONE, \
+        RADIO_INTERFACE_TYPE_AIDL, \
+        RADIO_##TYPE##_INTERFACE, \
+        RADIO_##TYPE, \
+        radio_aidl_indication_ifaces + 2*RADIO_##TYPE##_INTERFACE, \
+        radio_aidl_response_ifaces + 2*RADIO_##TYPE##_INTERFACE, \
+        radio_aidl_iface_info + RADIO_##TYPE##_INTERFACE, 1, \
+        GBINDER_STABILITY_VINTF, \
+        radio_read_response_info_aidl, \
+        RADIO_##TYPE##_REQ_SET_RESPONSE_FUNCTIONS, \
+        respAckReq, ackReqResp, rilConnectedInd
 
-static const char* const radio_ims_response_ifaces[] = {
-    RADIO_IMS_RESPONSE,
-    NULL
-};
-
-static const char* const radio_messaging_indication_ifaces[] = {
-    RADIO_MESSAGING_INDICATION,
-    NULL
-};
-
-static const char* const radio_messaging_response_ifaces[] = {
-    RADIO_MESSAGING_RESPONSE,
-    NULL
-};
-
-static const char* const radio_modem_indication_ifaces[] = {
-    RADIO_MODEM_INDICATION,
-    NULL
-};
-
-static const char* const radio_modem_response_ifaces[] = {
-    RADIO_MODEM_RESPONSE,
-    NULL
-};
-
-static const char* const radio_network_indication_ifaces[] = {
-    RADIO_NETWORK_INDICATION,
-    NULL
-};
-
-static const char* const radio_network_response_ifaces[] = {
-    RADIO_NETWORK_RESPONSE,
-    NULL
-};
-
-static const char* const radio_sim_indication_ifaces[] = {
-    RADIO_SIM_INDICATION,
-    NULL
-};
-
-static const char* const radio_sim_response_ifaces[] = {
-    RADIO_SIM_RESPONSE,
-    NULL
-};
-
-static const char* const radio_voice_indication_ifaces[] = {
-    RADIO_VOICE_INDICATION,
-    NULL
-};
-
-static const char* const radio_voice_response_ifaces[] = {
-    RADIO_VOICE_RESPONSE,
-    NULL
-};
+#define AIDL_INTERFACE_DESC(TYPE) \
+        AIDL_INTERFACE_DESC_(TYPE, \
+        RADIO_##TYPE##_REQ_RESPONSE_ACKNOWLEDGEMENT, \
+        RADIO_##TYPE##_RESP_ACKNOWLEDGE_REQUEST, \
+        RADIO_IND_NONE)
 
 static const RadioInterfaceDesc radio_aidl_interfaces[] = {
-    {
-        RADIO_INTERFACE_NONE,
-        RADIO_DATA_INTERFACE,
-        RADIO_DATA,
-        radio_data_indication_ifaces,
-        radio_data_response_ifaces,
-        radio_instance_read_aidl_response_info,
-        RADIO_DATA_REQ_SET_RESPONSE_FUNCTIONS,
-        RADIO_DATA_REQ_RESPONSE_ACKNOWLEDGEMENT,
-        RADIO_DATA_RESP_ACKNOWLEDGE_REQUEST
-    },
-    {
-        RADIO_INTERFACE_NONE,
-        RADIO_IMS_INTERFACE,
-        RADIO_IMS,
-        radio_ims_indication_ifaces,
-        radio_ims_response_ifaces,
-        radio_instance_read_aidl_response_info,
-        RADIO_IMS_REQ_SET_RESPONSE_FUNCTIONS,
+    { AIDL_INTERFACE_DESC(DATA) },
+    { AIDL_INTERFACE_DESC_(IMS,
         RADIO_REQ_NONE,
-        RADIO_RESP_NONE
-    },
-    {
-        RADIO_INTERFACE_NONE,
-        RADIO_MESSAGING_INTERFACE,
-        RADIO_MESSAGING,
-        radio_messaging_indication_ifaces,
-        radio_messaging_response_ifaces,
-        radio_instance_read_aidl_response_info,
-        RADIO_MESSAGING_REQ_SET_RESPONSE_FUNCTIONS,
-        RADIO_MESSAGING_REQ_RESPONSE_ACKNOWLEDGEMENT,
-        RADIO_MESSAGING_RESP_ACKNOWLEDGE_REQUEST
-    },
-    {
-        RADIO_INTERFACE_NONE,
-        RADIO_MODEM_INTERFACE,
-        RADIO_MODEM,
-        radio_modem_indication_ifaces,
-        radio_modem_response_ifaces,
-        radio_instance_read_aidl_response_info,
-        RADIO_MODEM_REQ_SET_RESPONSE_FUNCTIONS,
+        RADIO_RESP_NONE,
+        RADIO_IND_NONE) },
+    { AIDL_INTERFACE_DESC(MESSAGING) },
+    { AIDL_INTERFACE_DESC_(MODEM,
         RADIO_MODEM_REQ_RESPONSE_ACKNOWLEDGEMENT,
-        RADIO_MODEM_RESP_ACKNOWLEDGE_REQUEST
-    },
-    {
-        RADIO_INTERFACE_NONE,
-        RADIO_NETWORK_INTERFACE,
-        RADIO_NETWORK,
-        radio_network_indication_ifaces,
-        radio_network_response_ifaces,
-        radio_instance_read_aidl_response_info,
-        RADIO_NETWORK_REQ_SET_RESPONSE_FUNCTIONS,
-        RADIO_NETWORK_REQ_RESPONSE_ACKNOWLEDGEMENT,
-        RADIO_NETWORK_RESP_ACKNOWLEDGE_REQUEST
-    },
-    {
-        RADIO_INTERFACE_NONE,
-        RADIO_SIM_INTERFACE,
-        RADIO_SIM,
-        radio_sim_indication_ifaces,
-        radio_sim_response_ifaces,
-        radio_instance_read_aidl_response_info,
-        RADIO_SIM_REQ_SET_RESPONSE_FUNCTIONS,
-        RADIO_SIM_REQ_RESPONSE_ACKNOWLEDGEMENT,
-        RADIO_SIM_RESP_ACKNOWLEDGE_REQUEST
-    },
-    {
-        RADIO_INTERFACE_NONE,
-        RADIO_VOICE_INTERFACE,
-        RADIO_VOICE,
-        radio_voice_indication_ifaces,
-        radio_voice_response_ifaces,
-        radio_instance_read_aidl_response_info,
-        RADIO_VOICE_REQ_SET_RESPONSE_FUNCTIONS,
-        RADIO_VOICE_REQ_RESPONSE_ACKNOWLEDGEMENT,
-        RADIO_VOICE_RESP_ACKNOWLEDGE_REQUEST
-    }
+        RADIO_MODEM_RESP_ACKNOWLEDGE_REQUEST,
+        RADIO_MODEM_IND_RIL_CONNECTED) },
+    { AIDL_INTERFACE_DESC(NETWORK) },
+    { AIDL_INTERFACE_DESC(SIM) },
+    { AIDL_INTERFACE_DESC(VOICE) }
 };
 G_STATIC_ASSERT(G_N_ELEMENTS(radio_aidl_interfaces) == RADIO_AIDL_INTERFACE_COUNT);
 
@@ -376,27 +272,6 @@ typedef struct radio_instance_tx {
 /*==========================================================================*
  * Implementation
  *==========================================================================*/
-
-static
-const RadioResponseInfo*
-radio_instance_read_hidl_response_info(
-    GBinderReader* reader)
-{
-    return gbinder_reader_read_hidl_struct(reader, RadioResponseInfo);
-}
-
-static
-const RadioResponseInfo*
-radio_instance_read_aidl_response_info(
-    GBinderReader* reader)
-{
-    gsize size = 0;
-    const RadioResponseInfo* info = gbinder_reader_read_parcelable
-        (reader, &size);
-
-    GASSERT(size >= sizeof(*info));
-    return (size >= sizeof(*info)) ? info : NULL;
-}
 
 static
 GQuark
@@ -485,16 +360,10 @@ radio_instance_indication(
     void* user_data)
 {
     RadioInstance* self = RADIO_INSTANCE(user_data);
+    const RadioInterfaceDesc* desc = self->priv->desc;
     const char* iface = gbinder_remote_request_interface(req);
 
-    if (gutil_strv_contains((const GStrV*)radio_indication_ifaces, iface)
-        || gutil_strv_contains((const GStrV*)radio_data_indication_ifaces, iface)
-        || gutil_strv_contains((const GStrV*)radio_ims_indication_ifaces, iface)
-        || gutil_strv_contains((const GStrV*)radio_messaging_indication_ifaces, iface)
-        || gutil_strv_contains((const GStrV*)radio_modem_indication_ifaces, iface)
-        || gutil_strv_contains((const GStrV*)radio_network_indication_ifaces, iface)
-        || gutil_strv_contains((const GStrV*)radio_sim_indication_ifaces, iface)
-        || gutil_strv_contains((const GStrV*)radio_voice_indication_ifaces, iface)) {
+    if (gutil_strv_contains((const GStrV*)desc->ind_ifaces, iface)) {
         GBinderReader reader;
         guint type;
 
@@ -508,7 +377,6 @@ radio_instance_indication(
                 SIGNAL_OBSERVE_INDICATION_0;
             int p = RADIO_OBSERVER_PRIORITY_HIGHEST;
             gboolean handled = FALSE;
-            guint ind_ril_connected = 0;
 
             /* High-priority observers are notified first */
             for (; p > RADIO_OBSERVER_PRIORITY_DEFAULT; p--) {
@@ -520,14 +388,7 @@ radio_instance_indication(
             }
 
             /* rilConnected is a special case */
-            if (self->interface_type == RADIO_INTERFACE_TYPE_HIDL) {
-                ind_ril_connected = RADIO_IND_RIL_CONNECTED;
-            } else if (self->interface_type == RADIO_INTERFACE_TYPE_AIDL
-                && gutil_strv_contains((const GStrV*)radio_modem_indication_ifaces, iface)) {
-                ind_ril_connected = RADIO_MODEM_IND_RIL_CONNECTED;
-            }
-
-            if (ind_ril_connected && code == ind_ril_connected) {
+            if (code == desc->ril_connected_ind) {
                 if (G_UNLIKELY(self->connected)) {
                     /* We are only supposed to receive it once */
                     GWARN("%s received unexpected rilConnected", self->slot);
@@ -722,7 +583,7 @@ radio_instance_gone(
 
 static
 RadioInstance*
-radio_instance_create_version(
+radio_instance_create_desc(
     GBinderServiceManager* sm,
     GBinderRemoteObject* remote,
     const char* dev,
@@ -745,6 +606,8 @@ radio_instance_create_version(
     self->slot_index = slot_index;
     self->version = desc->version;
     self->interface_aidl = desc->aidl_interface;
+    self->interface_type = desc->interface_type;
+    self->connected = !desc->ril_connected_ind; /* no signal => connected */
 
     priv->desc = desc;
     priv->remote = gbinder_remote_object_ref(remote);
@@ -754,19 +617,11 @@ radio_instance_create_version(
         desc->resp_ifaces, radio_instance_response, self);
     priv->death_id = gbinder_remote_object_add_death_handler(remote,
         radio_instance_died, self);
+    priv->client = gbinder_client_new2(remote, desc->iface_info,
+        desc->iface_info_count);
 
-    if (desc->version != RADIO_INTERFACE_NONE) {
-        self->interface_type = RADIO_INTERFACE_TYPE_HIDL;
-        priv->client = gbinder_client_new2(remote,
-            radio_iface_info, G_N_ELEMENTS(radio_iface_info));
-    } else if (desc->aidl_interface != RADIO_AIDL_INTERFACE_NONE) {
-        self->interface_type = RADIO_INTERFACE_TYPE_AIDL;
-        priv->client = gbinder_client_new2(remote,
-            radio_aidl_iface_info + desc->aidl_interface, 1);
-
-        gbinder_local_object_set_stability(priv->indication, GBINDER_STABILITY_VINTF);
-        gbinder_local_object_set_stability(priv->response, GBINDER_STABILITY_VINTF);
-    }
+    gbinder_local_object_set_stability(priv->indication, desc->stability);
+    gbinder_local_object_set_stability(priv->response, desc->stability);
 
     /* IRadio::setResponseFunctions */
     req = gbinder_client_new_request2(priv->client,
@@ -830,7 +685,7 @@ radio_instance_create(
 
             if (obj) {
                 GINFO("Connected to %s", fqname);
-                self = radio_instance_create_version(sm, obj, dev, slot,
+                self = radio_instance_create_desc(sm, obj, dev, slot,
                     key, modem, slot_index, desc);
             }
             g_free(fqname);

--- a/src/radio_util.c
+++ b/src/radio_util.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2026 Jolla Mobile Ltd
  * Copyright (C) 2018-2022 Jolla Ltd.
  * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
@@ -38,6 +39,8 @@
 #include "radio_instance.h"
 #include "radio_log.h"
 
+#include <gbinder.h>
+
 GLOG_MODULE_DEFINE("gbinder-radio");
 
 guint
@@ -51,6 +54,25 @@ radio_observer_priority_index(
     } else {
         return priority - RADIO_OBSERVER_PRIORITY_LOWEST;
     }
+}
+
+const RadioResponseInfo*
+radio_read_response_info_hidl(
+    GBinderReader* reader)
+{
+    return gbinder_reader_read_hidl_struct(reader, RadioResponseInfo);
+}
+
+const RadioResponseInfo*
+radio_read_response_info_aidl(
+    GBinderReader* reader)
+{
+    gsize size = 0;
+    const RadioResponseInfo* info = gbinder_reader_read_parcelable
+        (reader, &size);
+
+    GASSERT(size >= sizeof(*info));
+    return (size >= sizeof(*info)) ? info : NULL;
 }
 
 const char*

--- a/src/radio_util_p.h
+++ b/src/radio_util_p.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2026 Jolla Mobile Ltd
  * Copyright (C) 2021-2022 Jolla Ltd.
  * Copyright (C) 2021-2022 Slava Monich <slava.monich@jolla.com>
  *
@@ -43,6 +44,16 @@
 guint
 radio_observer_priority_index(
     RADIO_OBSERVER_PRIORITY priority)
+    RADIO_INTERNAL;
+
+const RadioResponseInfo*
+radio_read_response_info_hidl(
+    GBinderReader* reader)
+    RADIO_INTERNAL;
+
+const RadioResponseInfo*
+radio_read_response_info_aidl(
+    GBinderReader* reader)
     RADIO_INTERNAL;
 
 #endif /* RADIO_UTIL_PRIVATE_H */

--- a/unit/unit_client/unit_client.c
+++ b/unit/unit_client/unit_client.c
@@ -482,6 +482,13 @@ test_null(
     g_assert(!radio_client_add_connected_handler(NULL, NULL, NULL));
     g_assert_cmpint(radio_client_interface(NULL), == ,RADIO_INTERFACE_NONE);
 
+    g_assert_null(radio_client_req_name(NULL, 0));
+    g_assert_null(radio_client_resp_name(NULL, 0));
+    g_assert_null(radio_client_ind_name(NULL, 0));
+    g_assert_nonnull(radio_client_req_name(NULL, 1));
+    g_assert_nonnull(radio_client_resp_name(NULL, 1));
+    g_assert_nonnull(radio_client_ind_name(NULL, 1));
+
     radio_request_unref(NULL);
     radio_request_drop(NULL);
     radio_request_cancel(NULL);
@@ -527,6 +534,13 @@ test_basic(
     g_assert_cmpstr(radio_client_slot(client), == ,test.radio->slot);
     g_assert_cmpint(radio_client_interface(client), == , test.radio->version);
     g_assert(!radio_client_connected(client));
+
+    g_assert_null(radio_client_req_name(client, 0));
+    g_assert_null(radio_client_resp_name(client, 0));
+    g_assert_null(radio_client_ind_name(client, 0));
+    g_assert_nonnull(radio_client_req_name(client, 1));
+    g_assert_nonnull(radio_client_resp_name(client, 1));
+    g_assert_nonnull(radio_client_ind_name(client, 1));
 
     /* Adding NULL handler is a nop */
     g_assert(!radio_client_add_indication_handler(client, RADIO_IND_ANY,

--- a/unit/unit_config/unit_config.c
+++ b/unit/unit_config/unit_config.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2026 Jolla Mobile Ltd
  * Copyright (C) 2022 Jolla Ltd.
  * Copyright (C) 2022 Slava Monich <slava.monich@jolla.com>
  *
@@ -394,6 +395,8 @@ test_null(
     g_assert(!radio_config_add_indication_observer_with_priority(NULL,
         RADIO_CONFIG_IND_ANY, RADIO_OBSERVER_PRIORITY_LOWEST, NULL, NULL));
     g_assert(!radio_config_request_new(NULL, ERROR_REQ, NULL, NULL, NULL, NULL));
+    g_assert_cmpint(radio_config_interface_type(NULL), ==,
+        RADIO_INTERFACE_TYPE_NONE);
 
     radio_config_unref(NULL);
     radio_config_remove_handler(NULL, 0);
@@ -421,9 +424,7 @@ test_name(
     g_assert_cmpstr(radio_config_req_name(client,
         RADIO_CONFIG_REQ_GET_PHONE_CAPABILITY), == ,
         "getPhoneCapability");
-    g_assert_cmpstr(radio_config_req_name(client,
-        (RADIO_CONFIG_REQ)123), == ,
-        "123");
+    g_assert_null(radio_config_req_name(client, (RADIO_CONFIG_REQ)123));
 
     g_assert_cmpstr(radio_config_resp_name(client,
         RADIO_CONFIG_RESP_GET_SIM_SLOTS_STATUS), == ,
@@ -431,16 +432,12 @@ test_name(
     g_assert_cmpstr(radio_config_resp_name(client,
         RADIO_CONFIG_RESP_GET_PHONE_CAPABILITY), == ,
         "getPhoneCapabilityResponse");
-    g_assert_cmpstr(radio_config_resp_name(client,
-        (RADIO_CONFIG_RESP)1234), == ,
-        "1234");
+    g_assert_null(radio_config_resp_name(client, (RADIO_CONFIG_RESP)1234));
 
     g_assert_cmpstr(radio_config_ind_name(client,
         RADIO_CONFIG_IND_SIM_SLOTS_STATUS_CHANGED), == ,
         "simSlotsStatusChanged");
-    g_assert_cmpstr(radio_config_ind_name(client,
-        (RADIO_CONFIG_IND)12345), == ,
-        "12345");
+    g_assert_null(radio_config_ind_name(client, (RADIO_CONFIG_IND)12345));
 
     test_common_cleanup(&test);
 }
@@ -455,7 +452,10 @@ test_none(
     void)
 {
     /* No service => no client */
-    g_assert(!radio_config_new());
+    g_assert_null(radio_config_new());
+    /* Invalid interface type */
+    g_assert_null(radio_config_new_with_version_and_interface_type(0,
+        RADIO_INTERFACE_TYPE_NONE));
 }
 
 /*==========================================================================*
@@ -477,6 +477,8 @@ test_basic(
     g_assert(radio_config_rpc_header_size(client,
         RADIO_CONFIG_REQ_GET_SIM_SLOTS_STATUS));
     g_assert_cmpint(radio_config_interface(client), == ,version);
+    g_assert_cmpint(radio_config_interface_type(client), == ,
+        RADIO_INTERFACE_TYPE_HIDL);
     g_assert(radio_config_ref(client) == client);
     radio_config_unref(client);
 


### PR DESCRIPTION
Only `IRadioModemIndication.aidl` and `IRadioIndication.hal` interfaces have that signal.

All interface type specific details have been moved to `RadioInterfaceDesc`.